### PR TITLE
🧹 Remove unused CSS form classes

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -98,78 +98,6 @@ body {
   opacity: 0.9;
 }
 
-.controls {
-  background: var(--color-background);
-  padding: var(--spacing-lg);
-  border-radius: var(--radius-lg);
-  margin-bottom: var(--spacing-xl);
-  box-shadow: var(--shadow-sm);
-}
-
-.form-group {
-  margin-bottom: var(--spacing-md);
-}
-
-.form-group:last-child {
-  margin-bottom: 0;
-}
-
-.form-label {
-  display: block;
-  margin-bottom: var(--spacing-sm);
-  font-weight: 600;
-  color: var(--color-text-muted);
-}
-
-.form-textarea {
-  width: 100%;
-  padding: var(--spacing-md);
-  border: 2px solid var(--color-border);
-  border-radius: var(--radius-md);
-  font-family: var(--font-family-mono);
-  font-size: 0.9rem;
-  resize: vertical;
-  min-height: 150px;
-  transition: border-color var(--transition-fast);
-}
-
-.form-textarea:focus {
-  outline: none;
-  border-color: var(--color-primary);
-}
-
-.form-textarea:focus-visible {
-  outline: 3px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
-.radio-group {
-  display: flex;
-  gap: var(--spacing-lg);
-  align-items: center;
-  flex-wrap: wrap;
-}
-
-.radio-option {
-  display: flex;
-  align-items: center;
-  gap: var(--spacing-sm);
-  cursor: pointer;
-}
-
-.radio-option__input {
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  accent-color: var(--color-primary);
-}
-
-.radio-option__label {
-  margin: 0;
-  font-weight: normal;
-  cursor: pointer;
-}
-
 .btn {
   display: inline-flex;
   align-items: center;
@@ -367,11 +295,6 @@ body {
 
   .apps-grid {
     grid-template-columns: 1fr;
-  }
-
-  .radio-group {
-    flex-direction: column;
-    align-items: flex-start;
   }
 }
 


### PR DESCRIPTION
- 🎯 **What:** Removed unused CSS classes related to forms and UI controls (`.controls`, `.form-group`, `.form-label`, `.form-textarea`, `.radio-group`, `.radio-option`).
- 💡 **Why:** These classes were dead code and not used anywhere in the project, removing them improves maintainability and reduces CSS file size.
- ✅ **Verification:** Verified by searching for these classes throughout the codebase and confirming they are not used in HTML or JS files. Ran server tests and performed visual verification of the frontend with Playwright.
- ✨ **Result:** Improved codebase cleanliness and reduced technical debt by removing approximately 70 lines of unused CSS.

---
*PR created automatically by Jules for task [2363503886575909994](https://jules.google.com/task/2363503886575909994) started by @damacus*