### PR TITLE
🧪 [testing improvement] Add test for initKubernetesClient fallback

### DIFF
--- a/server/main_test.go
+++ b/server/main_test.go
@@ -108,3 +108,25 @@ func TestHandleIngressesMethodAndFallback(t *testing.T) {
 		t.Fatalf("expected empty items when not running in cluster, got %d items", len(items))
 	}
 }
+
+func TestInitKubernetesClientFallback(t *testing.T) {
+	// Save original client and restore after test
+	originalClient := httpClient
+	defer func() { httpClient = originalClient }()
+
+	// Test fallback path
+	timeout := 7 * time.Second
+	initKubernetesClient(timeout)
+
+	if httpClient == nil {
+		t.Fatal("expected httpClient to be initialized, got nil")
+	}
+
+	if httpClient.Timeout != timeout {
+		t.Fatalf("expected timeout to be %v, got %v", timeout, httpClient.Timeout)
+	}
+
+	if httpClient.Transport != nil {
+		t.Fatalf("expected Transport to be nil in fallback path, got %v", httpClient.Transport)
+	}
+}


### PR DESCRIPTION
🎯 **What:** The `initKubernetesClient` function lacked testing, specifically for its fallback behavior when running outside a Kubernetes cluster.
📊 **Coverage:** The new test `TestInitKubernetesClientFallback` verifies that when the CA certificate cannot be read, the function initializes `httpClient` with the provided timeout and a `nil` custom TLS transport.
✨ **Result:** Increased test coverage for the application initialization logic and added a safety net for future refactoring.

---
*PR created automatically by Jules for task [6521014925678132037](https://jules.google.com/task/6521014925678132037) started by @damacus*