### PR TITLE
🧹 [code health improvement] Extract Kubernetes endpoint environment variable reading

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -127,9 +127,15 @@ func handleIngresses(timeout time.Duration) http.HandlerFunc {
 	}
 }
 
+func getKubernetesEndpoint() (string, string) {
+	apiServer := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_HOST"))
+	apiPort := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_PORT"))
+
+	return apiServer, apiPort
+}
+
 func fetchIngresses(ctx context.Context) (map[string]interface{}, error) {
-	apiServer := os.Getenv("KUBERNETES_SERVICE_HOST")
-	apiPort := os.Getenv("KUBERNETES_SERVICE_PORT")
+	apiServer, apiPort := getKubernetesEndpoint()
 
 	if apiServer == "" || apiPort == "" {
 		return map[string]interface{}{"items": []interface{}{}}, nil
@@ -248,8 +254,7 @@ func getEnvDuration(name string, fallback time.Duration) time.Duration {
 }
 
 func isReady() bool {
-	apiServer := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_HOST"))
-	apiPort := strings.TrimSpace(os.Getenv("KUBERNETES_SERVICE_PORT"))
+	apiServer, apiPort := getKubernetesEndpoint()
 
 	// Outside Kubernetes, always report ready for local/dev usage.
 	if apiServer == "" || apiPort == "" {


### PR DESCRIPTION
🎯 **What:** Extracted the reading of `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` environment variables into a single `getKubernetesEndpoint()` helper function.
💡 **Why:** Reduces code duplication between `fetchIngresses` and `isReady()`, standardizes the usage of `strings.TrimSpace` for robust parsing, and improves overall maintainability.
✅ **Verification:** Verified existing unit tests pass, confirming no regression in functionality or endpoints behavior.
✨ **Result:** Cleaned up repetitive environmental checks in server endpoints logic.

---
*PR created automatically by Jules for task [4081671810050194378](https://jules.google.com/task/4081671810050194378) started by @damacus*