### PR TITLE
🔒 Prevent sensitive information exposure in HTTP error response

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -117,7 +117,7 @@ func handleIngresses(timeout time.Duration) http.HandlerFunc {
 		ingresses, err := fetchIngresses(ctx)
 		if err != nil {
 			log.Printf("Error fetching ingresses: %v", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
 		}
 


### PR DESCRIPTION
🎯 **What:** Fixed sensitive information exposure in the `/api/ingresses` endpoint.
⚠️ **Risk:** Internal system details and Kubernetes API errors were being leaked to clients, potentially aiding an attacker in reconnaissance.
🛡️ **Solution:** Replaced detailed error messages in the HTTP response with a generic "Internal server error" while keeping the detailed logs server-side.

---
*PR created automatically by Jules for task [5475753574240450116](https://jules.google.com/task/5475753574240450116) started by @damacus*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-pager/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
