### PR TITLE
Fix Renovate workflow token fallback

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -37,18 +37,26 @@ jobs:
   main:
     name: Renovate
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      RENOVATE_APP_ID: ${{ vars.BOT_APP_ID || secrets.BOT_APP_ID }}
+      RENOVATE_APP_PRIVATE_KEY: ${{ secrets.BOT_APP_PRIVATE_KEY }}
     steps:
-      - name: Generate Token
+      - name: Generate App Token
+        if: ${{ env.RENOVATE_APP_ID != '' && env.RENOVATE_APP_PRIVATE_KEY != '' }}
         uses: actions/create-github-app-token@v2.2.1
         id: app-token
         with:
-          app-id: "${{ secrets.BOT_APP_ID }}"
-          private-key: "${{ secrets.BOT_APP_PRIVATE_KEY }}"
+          app-id: "${{ env.RENOVATE_APP_ID }}"
+          private-key: "${{ env.RENOVATE_APP_PRIVATE_KEY }}"
 
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          token: "${{ steps.app-token.outputs.token }}"
+          token: "${{ steps.app-token.outputs.token || secrets.RENOVATE_TOKEN || github.token }}"
 
       - name: Run Renovate
         uses: renovatebot/github-action@v46.1.3
@@ -61,5 +69,5 @@ jobs:
           RENOVATE_PLATFORM: github
           RENOVATE_PLATFORM_COMMIT: true
         with:
-          token: "${{ steps.app-token.outputs.token }}"
+          token: "${{ steps.app-token.outputs.token || secrets.RENOVATE_TOKEN || github.token }}"
           renovate-version: "${{ inputs.version || 'latest' }}"


### PR DESCRIPTION
## Summary
- skip GitHub App token generation when the Renovate app credentials are not configured
- fall back to `RENOVATE_TOKEN` or `github.token` for checkout and Renovate execution
- keep the Renovate workflow running on `main` schedules instead of failing before checkout

## Testing
- reviewed the failing `main` Renovate run logs and confirmed the failure was `[@octokit/auth-app] appId option is required`
- no local test suite changes; this only updates the GitHub Actions workflow

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-pager/pull/32" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
