### PR TITLE
chore: enable Renovate PR automerge

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,9 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "automerge": true,
+  "automergeType": "pr",
   "extends": [
     "github>damacus/renovate-config"
-  ]
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
## Summary
- enable Renovate PR automerge in .renovaterc.json5
- use platform automerge so dependency PRs can merge after required checks pass

## Testing
- not run locally; configuration-only change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/damacus/home-pager/pull/34" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
